### PR TITLE
Fix #6 ("GET parameters stripped from URL")

### DIFF
--- a/requests_unixsocket/adapters.py
+++ b/requests_unixsocket/adapters.py
@@ -31,10 +31,6 @@ class UnixHTTPConnection(HTTPConnection):
         sock.connect(socket_path)
         self.sock = sock
 
-    def request(self, method, url, **kwargs):
-        url = urlparse(url).path
-        HTTPConnection.request(self, method, url, **kwargs)
-
 
 class UnixHTTPConnectionPool(HTTPConnectionPool):
     def __init__(self, socket_path, timeout=60):

--- a/requests_unixsocket/tests/test_requests_unixsocket.py
+++ b/requests_unixsocket/tests/test_requests_unixsocket.py
@@ -35,6 +35,28 @@ def test_unix_domain_adapter_ok():
         assert r.text == 'Hello world!'
 
 
+def test_unix_domain_adapter_url_with_query_params():
+    with UnixSocketServerThread() as usock_thread:
+        session = requests_unixsocket.Session('http+unix://')
+        urlencoded_usock = requests.compat.quote_plus(usock_thread.usock)
+        url = ('http+unix://%s'
+               '/containers/nginx/logs?timestamp=true' % urlencoded_usock)
+        logger.debug('Calling session.get(%r) ...', url)
+        r = session.get(url)
+        logger.debug(
+            'Received response: %r with text: %r and headers: %r',
+            r, r.text, r.headers)
+        assert r.status_code == 200
+        assert r.headers['server'] == 'waitress'
+        assert r.headers['X-Transport'] == 'unix domain socket'
+        assert r.headers['X-Requested-Path'] == '/containers/nginx/logs'
+        assert r.headers['X-Requested-Query-String'] == 'timestamp=true'
+        assert r.headers['X-Socket-Path'] == usock_thread.usock
+        assert isinstance(r.connection, requests_unixsocket.UnixAdapter)
+        assert r.url == url
+        assert r.text == 'Hello world!'
+
+
 def test_unix_domain_adapter_connection_error():
     session = requests_unixsocket.Session('http+unix://')
 

--- a/requests_unixsocket/testutils.py
+++ b/requests_unixsocket/testutils.py
@@ -48,6 +48,7 @@ class WSGIApp:
         response_headers = [
             ('X-Transport', 'unix domain socket'),
             ('X-Socket-Path', environ['SERVER_PORT']),
+            ('X-Requested-Query-String', environ['QUERY_STRING']),
             ('X-Requested-Path', environ['PATH_INFO'])]
         body_bytes = b'Hello world!'
         start_response(status_text, response_headers)


### PR DESCRIPTION
@mminer, @phobologic: How does this change look? It seems to me like I didn't need the `request` method at all. Am I wrong?

Closes #6 
