### PR TITLE
Improve the monkey-patching library to replicate requests more closely

### DIFF
--- a/requests_unixsocket/__init__.py
+++ b/requests_unixsocket/__init__.py
@@ -49,13 +49,13 @@ def head(url, **kwargs):
     kwargs.setdefault('allow_redirects', False)
     return request('head', url, **kwargs)
 
-def post(url, **kwargs):
-    return request('post', url, data=data, **kwargs)
+def post(url, data=None, json=None, **kwargs):
+    return request('post', url, data=data, json=json, **kwargs)
 
-def patch(url, **kwargs):
+def patch(url, data=None, **kwargs):
     return request('patch', url,  data=data, **kwargs)
 
-def put(url, **kwargs):
+def put(url, data=None, **kwargs):
     return request('put', url, data=data, **kwargs)
 
 def delete(url, **kwargs):

--- a/requests_unixsocket/__init__.py
+++ b/requests_unixsocket/__init__.py
@@ -55,19 +55,23 @@ def head(url, **kwargs):
     kwargs.setdefault('allow_redirects', False)
     return request('head', url, **kwargs)
 
+
 def post(url, data=None, json=None, **kwargs):
     return request('post', url, data=data, json=json, **kwargs)
 
+
 def patch(url, data=None, **kwargs):
-    return request('patch', url,  data=data, **kwargs)
+    return request('patch', url, data=data, **kwargs)
+
 
 def put(url, data=None, **kwargs):
     return request('put', url, data=data, **kwargs)
 
+
 def delete(url, **kwargs):
     return request('delete', url, **kwargs)
+
 
 def options(url, **kwargs):
     kwargs.setdefault('allow_redirects', True)
     return request('options', url, **kwargs)
-

--- a/requests_unixsocket/tests/test_requests_unixsocket.py
+++ b/requests_unixsocket/tests/test_requests_unixsocket.py
@@ -20,67 +20,11 @@ def test_unix_domain_adapter_ok():
         session = requests_unixsocket.Session('http+unix://')
         urlencoded_usock = requests.compat.quote_plus(usock_thread.usock)
         url = 'http+unix://%s/path/to/page' % urlencoded_usock
-        logger.debug('Calling session.get(%r) ...', url)
-        r = session.get(url)
-        logger.debug(
-            'Received response: %r with text: %r and headers: %r',
-            r, r.text, r.headers)
-        assert r.status_code == 200
-        assert r.headers['server'] == 'waitress'
-        assert r.headers['X-Transport'] == 'unix domain socket'
-        assert r.headers['X-Requested-Path'] == '/path/to/page'
-        assert r.headers['X-Socket-Path'] == usock_thread.usock
-        assert isinstance(r.connection, requests_unixsocket.UnixAdapter)
-        assert r.url == url
-        assert r.text == 'Hello world!'
 
-
-def test_unix_domain_adapter_url_with_query_params():
-    with UnixSocketServerThread() as usock_thread:
-        session = requests_unixsocket.Session('http+unix://')
-        urlencoded_usock = requests.compat.quote_plus(usock_thread.usock)
-        url = ('http+unix://%s'
-               '/containers/nginx/logs?timestamp=true' % urlencoded_usock)
-        logger.debug('Calling session.get(%r) ...', url)
-        r = session.get(url)
-        logger.debug(
-            'Received response: %r with text: %r and headers: %r',
-            r, r.text, r.headers)
-        assert r.status_code == 200
-        assert r.headers['server'] == 'waitress'
-        assert r.headers['X-Transport'] == 'unix domain socket'
-        assert r.headers['X-Requested-Path'] == '/containers/nginx/logs'
-        assert r.headers['X-Requested-Query-String'] == 'timestamp=true'
-        assert r.headers['X-Socket-Path'] == usock_thread.usock
-        assert isinstance(r.connection, requests_unixsocket.UnixAdapter)
-        assert r.url == url
-        assert r.text == 'Hello world!'
-
-
-def test_unix_domain_adapter_connection_error():
-    session = requests_unixsocket.Session('http+unix://')
-
-    with pytest.raises(requests.ConnectionError):
-        session.get('http+unix://socket_does_not_exist/path/to/page')
-
-
-def test_unix_domain_adapter_connection_proxies_error():
-    session = requests_unixsocket.Session('http+unix://')
-
-    with pytest.raises(ValueError) as excinfo:
-        session.get('http+unix://socket_does_not_exist/path/to/page',
-                    proxies={"http": "http://10.10.1.10:1080"})
-    assert ('UnixAdapter does not support specifying proxies'
-            in str(excinfo.value))
-
-
-def test_unix_domain_adapter_monkeypatch():
-    with UnixSocketServerThread() as usock_thread:
-        with requests_unixsocket.monkeypatch('http+unix://'):
-            urlencoded_usock = requests.compat.quote_plus(usock_thread.usock)
-            url = 'http+unix://%s/path/to/page' % urlencoded_usock
-            logger.debug('Calling requests.get(%r) ...', url)
-            r = requests.get(url)
+        for method in ['get', 'post', 'head', 'patch', 'put', 'delete',
+                       'options']:
+            logger.debug('Calling session.%s(%r) ...', method, url)
+            r = getattr(session, method)(url)
             logger.debug(
                 'Received response: %r with text: %r and headers: %r',
                 r, r.text, r.headers)
@@ -91,7 +35,87 @@ def test_unix_domain_adapter_monkeypatch():
             assert r.headers['X-Socket-Path'] == usock_thread.usock
             assert isinstance(r.connection, requests_unixsocket.UnixAdapter)
             assert r.url == url
-            assert r.text == 'Hello world!'
+            if method == 'head':
+                assert r.text == ''
+            else:
+                assert r.text == 'Hello world!'
 
+
+def test_unix_domain_adapter_url_with_query_params():
+    with UnixSocketServerThread() as usock_thread:
+        session = requests_unixsocket.Session('http+unix://')
+        urlencoded_usock = requests.compat.quote_plus(usock_thread.usock)
+        url = ('http+unix://%s'
+               '/containers/nginx/logs?timestamp=true' % urlencoded_usock)
+
+        for method in ['get', 'post', 'head', 'patch', 'put', 'delete',
+                       'options']:
+            logger.debug('Calling session.%s(%r) ...', method, url)
+            r = getattr(session, method)(url)
+            logger.debug(
+                'Received response: %r with text: %r and headers: %r',
+                r, r.text, r.headers)
+            assert r.status_code == 200
+            assert r.headers['server'] == 'waitress'
+            assert r.headers['X-Transport'] == 'unix domain socket'
+            assert r.headers['X-Requested-Path'] == '/containers/nginx/logs'
+            assert r.headers['X-Requested-Query-String'] == 'timestamp=true'
+            assert r.headers['X-Socket-Path'] == usock_thread.usock
+            assert isinstance(r.connection, requests_unixsocket.UnixAdapter)
+            assert r.url == url
+            if method == 'head':
+                assert r.text == ''
+            else:
+                assert r.text == 'Hello world!'
+
+
+def test_unix_domain_adapter_connection_error():
+    session = requests_unixsocket.Session('http+unix://')
+
+    for method in ['get', 'post', 'head', 'patch', 'put', 'delete', 'options']:
+        with pytest.raises(requests.ConnectionError):
+            getattr(session, method)(
+                'http+unix://socket_does_not_exist/path/to/page')
+
+
+def test_unix_domain_adapter_connection_proxies_error():
+    session = requests_unixsocket.Session('http+unix://')
+
+    for method in ['get', 'post', 'head', 'patch', 'put', 'delete', 'options']:
+        with pytest.raises(ValueError) as excinfo:
+            getattr(session, method)(
+                'http+unix://socket_does_not_exist/path/to/page',
+                proxies={"http": "http://10.10.1.10:1080"})
+        assert ('UnixAdapter does not support specifying proxies'
+                in str(excinfo.value))
+
+
+def test_unix_domain_adapter_monkeypatch():
+    with UnixSocketServerThread() as usock_thread:
+        with requests_unixsocket.monkeypatch('http+unix://'):
+            urlencoded_usock = requests.compat.quote_plus(usock_thread.usock)
+            url = 'http+unix://%s/path/to/page' % urlencoded_usock
+
+            for method in ['get', 'post', 'head', 'patch', 'put', 'delete',
+                           'options']:
+                logger.debug('Calling session.%s(%r) ...', method, url)
+                r = getattr(requests, method)(url)
+                logger.debug(
+                    'Received response: %r with text: %r and headers: %r',
+                    r, r.text, r.headers)
+                assert r.status_code == 200
+                assert r.headers['server'] == 'waitress'
+                assert r.headers['X-Transport'] == 'unix domain socket'
+                assert r.headers['X-Requested-Path'] == '/path/to/page'
+                assert r.headers['X-Socket-Path'] == usock_thread.usock
+                assert isinstance(r.connection,
+                                  requests_unixsocket.UnixAdapter)
+                assert r.url == url
+                if method == 'head':
+                    assert r.text == ''
+                else:
+                    assert r.text == 'Hello world!'
+
+    for method in ['get', 'post', 'head', 'patch', 'put', 'delete', 'options']:
         with pytest.raises(requests.exceptions.InvalidSchema):
-            requests.get(url)
+            getattr(requests, method)(url)


### PR DESCRIPTION
This patch modifies the monkey-patch library to properly patch all the requests built-in methods, providing a complete drop-in replacement.

This also means the library exports the requests methods of requests_unixsocket directly, following the usual requests exports.

The redundant __all__ line of the main module is removed for code clean-up.