### PR TITLE
Add urllib3 requirement.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=1.1
+urllib3>=1.8


### PR DESCRIPTION
``urllib3.connection`` is used in https://github.com/msabramo/requests-unixsocket/blob/master/requests_unixsocket/adapters.py#L9, which was added in 1.8 according to
https://github.com/shazow/urllib3/blob/master/CHANGES.rst

Having this requirement is useful, because for instance Ubuntu LTS ships with an older urllib3.