### PR TITLE
add data and json keyword arguments to request method

### DIFF
--- a/requests_unixsocket/__init__.py
+++ b/requests_unixsocket/__init__.py
@@ -41,7 +41,7 @@ class monkeypatch(object):
 
 
 # These are the same methods defined for the global requests object
-def request(method, url, **kwargs):
+def request(method, url, data=None, json=None, **kwargs):
     session = Session()
     return session.request(method=method, url=url, **kwargs)
 


### PR DESCRIPTION
Fixes error when using request.post() i.e. TypeError: request() got an unexpected keyword argument 'json'
--
Peter