### PR TITLE
add data and json keyword arguments to request method explicitly

### DIFF
--- a/requests_unixsocket/__init__.py
+++ b/requests_unixsocket/__init__.py
@@ -41,9 +41,9 @@ class monkeypatch(object):
 
 
 # These are the same methods defined for the global requests object
-def request(method, url, **kwargs):
+def request(method, url, data=None, json=None,**kwargs):
     session = Session()
-    return session.request(method=method, url=url, **kwargs)
+    return session.request(method=method, url=url, data=data, json=json, **kwargs)
 
 
 def get(url, **kwargs):


### PR DESCRIPTION
Fixes error when using request.post() and presumably other methods which rely upon data/json arguments.

Example error: "TypeError: request() got an unexpected keyword argument 'json'"