### PR TITLE
Override HTTPAdapter.request_url

### DIFF
--- a/requests_unixsocket/adapters.py
+++ b/requests_unixsocket/adapters.py
@@ -58,3 +58,6 @@ class UnixAdapter(HTTPAdapter):
             raise ValueError('%s does not support specifying proxies'
                              % self.__class__.__name__)
         return UnixHTTPConnectionPool(socket_path, self.timeout)
+
+    def request_url(self, request, proxies):
+        return request.path_url


### PR DESCRIPTION
Override `HTTPAdapter.request_url`, so that it doesn't call `select_proxy`.

Fixes: GH-21

See: https://github.com/kennethreitz/requests/issues/3131#issuecomment-214792914

Cc: @sigmavirus24