### PR TITLE
Non case sensitive url comparison in tests.

### DIFF
--- a/requests_unixsocket/tests/test_requests_unixsocket.py
+++ b/requests_unixsocket/tests/test_requests_unixsocket.py
@@ -34,7 +34,7 @@ def test_unix_domain_adapter_ok():
             assert r.headers['X-Requested-Path'] == '/path/to/page'
             assert r.headers['X-Socket-Path'] == usock_thread.usock
             assert isinstance(r.connection, requests_unixsocket.UnixAdapter)
-            assert r.url == url
+            assert r.url.lower() == url.lower()
             if method == 'head':
                 assert r.text == ''
             else:
@@ -62,7 +62,7 @@ def test_unix_domain_adapter_url_with_query_params():
             assert r.headers['X-Requested-Query-String'] == 'timestamp=true'
             assert r.headers['X-Socket-Path'] == usock_thread.usock
             assert isinstance(r.connection, requests_unixsocket.UnixAdapter)
-            assert r.url == url
+            assert r.url.lower() == url.lower()
             if method == 'head':
                 assert r.text == ''
             else:
@@ -110,7 +110,7 @@ def test_unix_domain_adapter_monkeypatch():
                 assert r.headers['X-Socket-Path'] == usock_thread.usock
                 assert isinstance(r.connection,
                                   requests_unixsocket.UnixAdapter)
-                assert r.url == url
+                assert r.url.lower() == url.lower()
                 if method == 'head':
                     assert r.text == ''
                 else:


### PR DESCRIPTION
Fix for unit tests.

py27 installed: apipkg==1.4,execnet==1.4.1,pep8==1.7.0,pkg-resources==0.0.0,py==1.4.32,pytest==3.0.5,pytest-cache==1.0,pytest-capturelog==0.7,pytest-pep8==1.0.6,requests==2.12.4,requests-unixsocket==0.1.6.dev3,urllib3==1.19.1,waitress==1.0.1

requests_unixsocket/tests/test_requests_unixsocket.py:37: in test_unix_domain_adapter_ok
    assert r.url == url
E   assert 'http+unix://.../path/to/page' == 'http+unix://%.../path/to/page'
E     Skipping 39 identical trailing characters in diff, use -v to show
E     - http+unix://%2ftmp%2ftest_requ
E     ?               ^     ^
E     + http+unix://%2Ftmp%2Ftest_requ
E     ?               ^     ^

requests_unixsocket/tests/test_requests_unixsocket.py:65: in test_unix_domain_adapter_url_with_query_params
    assert r.url == url
E   assert 'http+unix://...imestamp=true' == 'http+unix://%...imestamp=true'
E     Skipping 63 identical trailing characters in diff, use -v to show
E     - http+unix://%2ftmp%2ftest_requ
E     ?               ^     ^
E     + http+unix://%2Ftmp%2Ftest_requ
E     ?               ^     ^

requests_unixsocket/tests/test_requests_unixsocket.py:113: in test_unix_domain_adapter_monkeypatch
    assert r.url == url
E   assert 'http+unix://.../path/to/page' == 'http+unix://%.../path/to/page'
E     Skipping 39 identical trailing characters in diff, use -v to show
E     - http+unix://%2ftmp%2ftest_requ
E     ?               ^     ^
E     + http+unix://%2Ftmp%2Ftest_requ
E     ?               ^     ^