### PR TITLE
Alternative URL scheme

### DIFF
--- a/requests_unixsocket/__init__.py
+++ b/requests_unixsocket/__init__.py
@@ -1,9 +1,10 @@
+import os
 import requests
 import sys
 
 from .adapters import UnixAdapter
 
-DEFAULT_SCHEME = 'http+unix://'
+DEFAULT_SCHEME = os.getenv('REQUESTS_UNIXSOCKET_URL_SCHEME', 'http+unix://')
 
 
 class Session(requests.Session):

--- a/requests_unixsocket/__init__.py
+++ b/requests_unixsocket/__init__.py
@@ -4,18 +4,22 @@ import sys
 
 from .adapters import UnixAdapter
 
-DEFAULT_SCHEME = os.getenv('REQUESTS_UNIXSOCKET_URL_SCHEME', 'http+unix://')
+DEFAULT_SCHEMES = os.getenv(
+    'REQUESTS_UNIXSOCKET_URL_SCHEMES',
+    'http+unix://,http://sock.local/'
+).split(',')
 
 
 class Session(requests.Session):
-    def __init__(self, url_scheme=DEFAULT_SCHEME, *args, **kwargs):
+    def __init__(self, url_schemes=DEFAULT_SCHEMES, *args, **kwargs):
         super(Session, self).__init__(*args, **kwargs)
-        self.mount(url_scheme, UnixAdapter())
+        for url_scheme in url_schemes:
+            self.mount(url_scheme, UnixAdapter())
 
 
 class monkeypatch(object):
-    def __init__(self, url_scheme=DEFAULT_SCHEME):
-        self.session = Session()
+    def __init__(self, url_schemes=DEFAULT_SCHEMES):
+        self.session = Session(url_schemes=url_schemes)
         requests = self._get_global_requests_module()
 
         # Methods to replace

--- a/requests_unixsocket/tests/test_requests_unixsocket.py
+++ b/requests_unixsocket/tests/test_requests_unixsocket.py
@@ -196,8 +196,8 @@ def test_unix_domain_adapter_monkeypatch():
 
 def test_unix_domain_adapter_monkeypatch_alt_scheme():
     with UnixSocketServerThread() as usock_thread:
-        with requests_unixsocket.monkeypatch('http+unix://'):
-            url = 'http+unix://unix.socket%s/path/to/page' % usock_thread.usock
+        with requests_unixsocket.monkeypatch():
+            url = 'http://sock.local/%s/path/to/page' % usock_thread.usock
 
             for method in ['get', 'post', 'head', 'patch', 'put', 'delete',
                            'options']:
@@ -218,7 +218,3 @@ def test_unix_domain_adapter_monkeypatch_alt_scheme():
                     assert r.text == ''
                 else:
                     assert r.text == 'Hello world!'
-
-    for method in ['get', 'post', 'head', 'patch', 'put', 'delete', 'options']:
-        with pytest.raises(requests.exceptions.InvalidSchema):
-            getattr(requests, method)(url)

--- a/requests_unixsocket/tests/test_requests_unixsocket.py
+++ b/requests_unixsocket/tests/test_requests_unixsocket.py
@@ -41,12 +41,64 @@ def test_unix_domain_adapter_ok():
                 assert r.text == 'Hello world!'
 
 
+def test_unix_domain_adapter_ok_alt_scheme():
+    with UnixSocketServerThread() as usock_thread:
+        session = requests_unixsocket.Session('http+unix://')
+        url = 'http+unix://unix.socket%s/path/to/page' % usock_thread.usock
+
+        for method in ['get', 'post', 'head', 'patch', 'put', 'delete',
+                       'options']:
+            logger.debug('Calling session.%s(%r) ...', method, url)
+            r = getattr(session, method)(url)
+            logger.debug(
+                'Received response: %r with text: %r and headers: %r',
+                r, r.text, r.headers)
+            assert r.status_code == 200
+            assert r.headers['server'] == 'waitress'
+            assert r.headers['X-Transport'] == 'unix domain socket'
+            assert r.headers['X-Requested-Path'] == '/path/to/page'
+            assert r.headers['X-Socket-Path'] == usock_thread.usock
+            assert isinstance(r.connection, requests_unixsocket.UnixAdapter)
+            assert r.url.lower() == url.lower()
+            if method == 'head':
+                assert r.text == ''
+            else:
+                assert r.text == 'Hello world!'
+
+
 def test_unix_domain_adapter_url_with_query_params():
     with UnixSocketServerThread() as usock_thread:
         session = requests_unixsocket.Session('http+unix://')
         urlencoded_usock = requests.compat.quote_plus(usock_thread.usock)
         url = ('http+unix://%s'
                '/containers/nginx/logs?timestamp=true' % urlencoded_usock)
+
+        for method in ['get', 'post', 'head', 'patch', 'put', 'delete',
+                       'options']:
+            logger.debug('Calling session.%s(%r) ...', method, url)
+            r = getattr(session, method)(url)
+            logger.debug(
+                'Received response: %r with text: %r and headers: %r',
+                r, r.text, r.headers)
+            assert r.status_code == 200
+            assert r.headers['server'] == 'waitress'
+            assert r.headers['X-Transport'] == 'unix domain socket'
+            assert r.headers['X-Requested-Path'] == '/containers/nginx/logs'
+            assert r.headers['X-Requested-Query-String'] == 'timestamp=true'
+            assert r.headers['X-Socket-Path'] == usock_thread.usock
+            assert isinstance(r.connection, requests_unixsocket.UnixAdapter)
+            assert r.url.lower() == url.lower()
+            if method == 'head':
+                assert r.text == ''
+            else:
+                assert r.text == 'Hello world!'
+
+
+def test_unix_domain_adapter_url_with_query_params_alt_scheme():
+    with UnixSocketServerThread() as usock_thread:
+        session = requests_unixsocket.Session('http+unix://')
+        url = ('http+unix://unix.socket%s'
+               '/containers/nginx/logs?timestamp=true' % usock_thread.usock)
 
         for method in ['get', 'post', 'head', 'patch', 'put', 'delete',
                        'options']:
@@ -78,6 +130,15 @@ def test_unix_domain_adapter_connection_error():
                 'http+unix://socket_does_not_exist/path/to/page')
 
 
+def test_unix_domain_adapter_connection_error_alt_scheme():
+    session = requests_unixsocket.Session('http+unix://')
+
+    for method in ['get', 'post', 'head', 'patch', 'put', 'delete', 'options']:
+        with pytest.raises(requests.ConnectionError):
+            getattr(session, method)(
+                'http+unix://unix.socket/socket_does_not_exist/path/to/page')
+
+
 def test_unix_domain_adapter_connection_proxies_error():
     session = requests_unixsocket.Session('http+unix://')
 
@@ -90,11 +151,53 @@ def test_unix_domain_adapter_connection_proxies_error():
                 in str(excinfo.value))
 
 
+def test_unix_domain_adapter_connection_proxies_error_alt_scheme():
+    session = requests_unixsocket.Session('http+unix://')
+
+    for method in ['get', 'post', 'head', 'patch', 'put', 'delete', 'options']:
+        with pytest.raises(ValueError) as excinfo:
+            getattr(session, method)(
+                'http+unix://unix.socket/socket_does_not_exist/path/to/page',
+                proxies={"http+unix": "http://10.10.1.10:1080"})
+        assert ('UnixAdapter does not support specifying proxies'
+                in str(excinfo.value))
+
+
 def test_unix_domain_adapter_monkeypatch():
     with UnixSocketServerThread() as usock_thread:
         with requests_unixsocket.monkeypatch('http+unix://'):
             urlencoded_usock = requests.compat.quote_plus(usock_thread.usock)
             url = 'http+unix://%s/path/to/page' % urlencoded_usock
+
+            for method in ['get', 'post', 'head', 'patch', 'put', 'delete',
+                           'options']:
+                logger.debug('Calling session.%s(%r) ...', method, url)
+                r = getattr(requests, method)(url)
+                logger.debug(
+                    'Received response: %r with text: %r and headers: %r',
+                    r, r.text, r.headers)
+                assert r.status_code == 200
+                assert r.headers['server'] == 'waitress'
+                assert r.headers['X-Transport'] == 'unix domain socket'
+                assert r.headers['X-Requested-Path'] == '/path/to/page'
+                assert r.headers['X-Socket-Path'] == usock_thread.usock
+                assert isinstance(r.connection,
+                                  requests_unixsocket.UnixAdapter)
+                assert r.url.lower() == url.lower()
+                if method == 'head':
+                    assert r.text == ''
+                else:
+                    assert r.text == 'Hello world!'
+
+    for method in ['get', 'post', 'head', 'patch', 'put', 'delete', 'options']:
+        with pytest.raises(requests.exceptions.InvalidSchema):
+            getattr(requests, method)(url)
+
+
+def test_unix_domain_adapter_monkeypatch_alt_scheme():
+    with UnixSocketServerThread() as usock_thread:
+        with requests_unixsocket.monkeypatch('http+unix://'):
+            url = 'http+unix://unix.socket%s/path/to/page' % usock_thread.usock
 
             for method in ['get', 'post', 'head', 'patch', 'put', 'delete',
                            'options']:


### PR DESCRIPTION
Add a much friendlier URL scheme:

e.g.: http://sock.local/var/run/docker.sock/version

while still supporting the old scheme too (http+unix://%2Fvar%2Frun%2Fdocker.sock/info)

The new scheme is nice, because it:

- uses the "standard" protocol of `http://` and doesn't invent a funky new one
- doesn't require ugly and error-prone (https://github.com/httpie/httpie-unixsocket/issues/7, https://github.com/httpie/httpie-unixsocket/issues/9) URL encoding of the socket path
- uses path part of URL instead of hostname for the socket path, thus avoiding issues with 63 character limit for hostnames in DNS/IDNA (e.g.: #23)

Cc: @jkbrzt, @jessfraz, @RantyDave, @Kobla, @habnabit, @graingert, @3XE, @esben, @avian2, @wrouesnel, @tjj5036, @rockstar