### PR TITLE
Allow UnixAdapter to accept max_retries parameter

### DIFF
--- a/requests_unixsocket/adapters.py
+++ b/requests_unixsocket/adapters.py
@@ -56,13 +56,12 @@ class UnixHTTPConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
 
 class UnixAdapter(HTTPAdapter):
 
-    def __init__(self, timeout=60, pool_connections=25):
-        super(UnixAdapter, self).__init__()
+    def __init__(self, timeout=60, pool_connections=25, *args, **kwargs):
+        super(UnixAdapter, self).__init__(*args, **kwargs)
         self.timeout = timeout
         self.pools = urllib3._collections.RecentlyUsedContainer(
             pool_connections, dispose_func=lambda p: p.close()
         )
-        super(UnixAdapter, self).__init__()
 
     def get_connection(self, url, proxies=None):
         proxies = proxies or {}


### PR DESCRIPTION
e.g.:

```python
from requests.packages.urllib3.util.retry import Retry
import requests_unixsocket

sess = requests_unixsocket.Session()

HTTP_REQUEST_RETRIES = 3
HTTP_RETRY_BACKOFF_FACTOR = 0.3
HTTP_RETRY_FORCELIST = (404, 500, 502, 504)

retry = Retry(total=HTTP_REQUEST_RETRIES,
              read=HTTP_REQUEST_RETRIES,
              connect=HTTP_REQUEST_RETRIES,
              backoff_factor=HTTP_RETRY_BACKOFF_FACTOR,
              status_forcelist=HTTP_RETRY_FORCELIST)

adapter = requests_unixsocket.UnixAdapter(max_retries=retry)
sess.mount('http+unix://', adapter)

print(sess.get('http+unix://%2Fvar%2Frun%2Fdocker.sock/this-does-not-exist'))
```

Fixes: GH-37

Cc: @fantamiracle, @keith-bennett-gbg