### PR TITLE
Remove urllib3 dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 requests>=1.1
-urllib3>=1.8


### PR DESCRIPTION
since we can use the version bundled with `requests`.

Fixes: GH-45