### PR TITLE
test: add test_use_UnixAdapter_directly

### DIFF
--- a/requests_unixsocket/tests/test_requests_unixsocket.py
+++ b/requests_unixsocket/tests/test_requests_unixsocket.py
@@ -15,6 +15,19 @@ from requests_unixsocket.testutils import UnixSocketServerThread
 logger = logging.getLogger(__name__)
 
 
+def test_use_UnixAdapter_directly():
+    """Test using UnixAdapter directly, because
+    https://github.com/httpie/httpie-unixsocket does this
+    """
+    adapter = requests_unixsocket.UnixAdapter()
+    prepared_request = requests.Request(
+        method='GET',
+        url='http+unix://%2Fvar%2Frun%2Fdocker.sock/info',
+    ).prepare()
+    url = adapter.request_url(request=prepared_request, proxies=None)
+    assert url == '/info'
+
+
 def test_unix_domain_adapter_ok():
     with UnixSocketServerThread() as usock_thread:
         session = requests_unixsocket.Session('http+unix://')


### PR DESCRIPTION
This new test tests using the `UnixAdapter` directly, like
[httpie-unixsocket](https://github.com/httpie/httpie-unixsocket) does.

I wrote this test because I found a case, on the `pluggable-urlparse`
branch, where tests were passing, but executing:

```
http http+unix://%2Fvar%2Frun%2Fdocker.sock/info
```

was failing.