### PR TITLE
Inherit HTTPConnection through urllib3.connection, not httplib

### DIFF
--- a/requests_unixsocket/adapters.py
+++ b/requests_unixsocket/adapters.py
@@ -4,11 +4,6 @@ from requests.adapters import HTTPAdapter
 from requests.compat import urlparse, unquote
 
 try:
-    import http.client as httplib
-except ImportError:
-    import httplib
-
-try:
     from requests.packages import urllib3
 except ImportError:
     import urllib3
@@ -16,7 +11,7 @@ except ImportError:
 
 # The following was adapted from some code from docker-py
 # https://github.com/docker/docker-py/blob/master/docker/transport/unixconn.py
-class UnixHTTPConnection(httplib.HTTPConnection, object):
+class UnixHTTPConnection(urllib3.connection.HTTPConnection, object):
 
     def __init__(self, unix_socket_url, timeout=60):
         """Create an HTTP connection to a unix domain socket


### PR DESCRIPTION
By inheriting from `urllib3.connection.HTTPConnection` (that inherits from `httplib.HTTPConnection` itself), we can adapt to the internal changes in urllib3 2.0 that added a `request()` method that is incompatible with httplib.HTTPConnection.request.

This fixes the incompatibility between urllib3 2.0 and requests 1.26+, which was the first version that stopped vendoring urllib3.

Reference: https://github.com/docker/docker-py/issues/3113#issuecomment-1531570788