### PR TITLE
testutils: fix test flake on HEAD request

### DIFF
--- a/requests_unixsocket/testutils.py
+++ b/requests_unixsocket/testutils.py
@@ -51,6 +51,8 @@ class WSGIApp:
             ('X-Requested-Query-String', environ['QUERY_STRING']),
             ('X-Requested-Path', environ['PATH_INFO'])]
         body_bytes = b'Hello world!'
+        if environ['REQUEST_METHOD'] == 'HEAD':
+            body_bytes = b''
         start_response(status_text, response_headers)
         logger.debug(
             'WSGIApp.__call__: Responding with '


### PR DESCRIPTION
testutils: fix test flake on HEAD request

Flakiness may be observed when running the unit tests.
The symptom of that looks like:
requests.exceptions.ConnectionError: ('Connection aborted.',
BadStatusLine('Hello world!HTTP/1.1 200 OK\r\n'))

We believe that, with the correct send and recv timing, the "Hello
world!" body from a HEAD request will be left unread in the reused
socket, resulting in an invalid read for the next request along.

Co-authored-by: Olivier Gayot <olivier.gayot@canonical.com>