### PR TITLE
📦 Wire pbr via PEP 517

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+  "pbr >= 6",
+  "setuptools >= 64",
+]
+build-backend = "pbr.build"


### PR DESCRIPTION
This is necessary for the modern packaging tooling to be able to build the dists.