### PR TITLE
Replace deprecated `pep8` tool with `flake8` in test infra and CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -366,6 +366,7 @@ jobs:
         toxenv:
         # - pre-commit
         - metadata-validation
+        - flake8
         # - build-docs
         # - coverage-docs
         # - doctest-docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ build-backend = "setuptools.build_meta"
 building = [
   "build",
 ]
+linting = [
+  "flake8",
+]
 testing = [
   "pytest",
   "pytest-cache",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,8 @@ building = [
   "build",
 ]
 testing = [
-  "pep8",
   "pytest",
   "pytest-cache",
-  "pytest-pep8",
   "waitress",
 ]
 upstreaming = [

--- a/requests_unixsocket/adapters.py
+++ b/requests_unixsocket/adapters.py
@@ -75,7 +75,13 @@ class UnixAdapter(HTTPAdapter):
         )
 
     # Fix for requests 2.32.2+: https://github.com/psf/requests/pull/6710
-    def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
+    def get_connection_with_tls_context(
+        self,
+        request,
+        verify,
+        proxies=None,
+        cert=None,
+    ):
         return self.get_connection(request.url, proxies)
 
     def get_connection(self, url, proxies=None):

--- a/tox.ini
+++ b/tox.ini
@@ -124,4 +124,4 @@ commands = python setup.py build_sphinx
 
 [flake8]
 max_line_length = 79
-exclude = .git,.tox,dist,docs,*egg
+exclude = .*,dist,docs,*egg

--- a/tox.ini
+++ b/tox.ini
@@ -123,4 +123,4 @@ commands = python setup.py build_sphinx
 
 [flake8]
 max_line_length = 79
-exclude = .*,dist,docs,*egg
+exclude = .git,.tox,dist,docs,*egg

--- a/tox.ini
+++ b/tox.ini
@@ -88,8 +88,6 @@ package = skip
 
 [testenv:flake8]
 commands = flake8
-deps =
-    flake8
 dependency_groups =
   linting
 

--- a/tox.ini
+++ b/tox.ini
@@ -90,7 +90,8 @@ package = skip
 commands = flake8
 deps =
     flake8
-    {[testenv]deps}
+dependency_groups =
+  linting
 
 [testenv:venv]
 commands = {posargs}


### PR DESCRIPTION
- flake8 added to the CI matrix
- flake8 violation addressed
- pep8 (unused) dependency removed as flake8 replaces it.
- altered flake8 exclusions to include `.*` to cover existing `.git` and `.tox`, but also any other hidden files and directories, e.g. `.venv`
